### PR TITLE
Fix syntax issues for python execution

### DIFF
--- a/fruitPOP_sortingHat.py
+++ b/fruitPOP_sortingHat.py
@@ -6,7 +6,14 @@
 # • gspread_dataframe– Helper: move whole DataFrames in/out of Sheets
 # • oauth2client     – Handles the OAuth dance inside Colab
 # =============================================================================
-!pip install -q ortools gspread gspread_dataframe oauth2client
+import subprocess, sys
+
+# Install required libraries when executed outside of a notebook.
+subprocess.run(
+    [sys.executable, "-m", "pip", "install", "-q",
+     "ortools", "gspread", "gspread_dataframe", "oauth2client"],
+    check=True,
+)
 
 # =============================================================================
 # 1.  Authenticate this Colab session with your Google account
@@ -291,7 +298,8 @@ for i in range(1, 21):
 summary_df = pd.DataFrame(summary_rows)
 
 # Append a blank line then the summary table to audit_df
-blank_row = pd.DataFrame([{'Volunteer': ''} | {}])  # minimal blank
+# Using an explicit dictionary avoids relying on Python 3.9+'s dict union.
+blank_row = pd.DataFrame([{'Volunteer': ''}])  # minimal blank
 audit_df  = pd.concat([audit_df, blank_row, summary_df], ignore_index=True)
 
 # Footer


### PR DESCRIPTION
## Summary
- make package install step cross-platform
- avoid using dict union syntax in one spot

## Testing
- `python -m py_compile fruitPOP_sortingHat.py`

------
https://chatgpt.com/codex/tasks/task_e_683f8411371c832b837f8001f2e95348